### PR TITLE
Update `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
 [![Build Status][ubuntu-build-badge]][gh-actions]
 [![Build Status][windows-build-badge]][gh-actions]
-[![license][license-badge]](http://www.apache.org/licenses/LICENSE-2.0)
-
-[gh-actions]: https://github.com/spine-examples/Hello-ProtoData/actions
-[ubuntu-build-badge]: https://github.com/spine-examples/Hello-ProtoData/actions/workflows/build-on-ubuntu.yml/badge.svg
-[windows-build-badge]: https://github.com/spine-examples/Hello-ProtoData/actions/workflows/build-on-windows.yml/badge.svg
-[license-badge]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat
+[![license][license-badge]][apache-license]
 
 # Introduction
 
 Declarations in a `.proto` file can be annotated with 
-a number of [options](https://protobuf.dev/programming-guides/proto3/#options). 
+a number of [options][proto3-options].
 Options do not change the overall meaning of a declaration, 
 but may affect the way it is handled in a particular context.
 
 Protobuf supports different types of options, e.g. file-level options, 
-message-level options, field-level options, etc. The complete list of 
-available options is defined in 
-[/google/protobuf/descriptor.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto).
+message-level options, field-level options, etc. The list of 
+available options types is defined in 
+[/google/protobuf/descriptor.proto][descriptor-proto].
 
-Protobuf also allows to define and use [custom options](https://protobuf.dev/programming-guides/proto2/#customoptions). 
+Protobuf also allows to define and use [custom options][proto3-custom-options]. 
 The authors say "that this is an advanced feature which most people don’t need" 
 and it actually requires a significant amount of work to define a custom option 
 and generate the validation code for this option. However, ProtoData provides 
@@ -29,12 +24,13 @@ generated code with the desired behaviour.
 # Domain
 
 This use-case of applying ProtoData demonstrates how to enrich the model 
-with additional semantic elements and reflect its meaning in the generated code.
+with additional semantic elements and reflect their meaning in the generated 
+code.
 
-For example, let's define a board for TicTacToe game:
+For example, let's define a board for Tic-tac-toe game:
 
 ```protobuf
-// A board for TicTacToe game.
+// A board for Tic-tac-toe game.
 message Board {
   // The name of the board.
   BoardName name = 1;
@@ -68,18 +64,21 @@ the model becomes invalid state. What can we do to avoid this?
 
 It would be much better if we could add the following:
 
-1. Mark some fields as `required` to admit that this is important
-to initialize these fields.
+1. Mark some fields as `required` to state the absolute necessity to fill them 
+with real values.
 2. Set the minimum acceptable value for the `side_size` field.
 3. Add some validation rules that verify the size of the `cell` collection.
+Indeed, a tic-tac-toe board should be square, and hence have an appropriate 
+number of cells, being the size of the side squared.
 
-We can easily solve the points 1 and 2 as ProtoData provides options 
-to mark the fields as `required` and validate values of the numeric fields.
+We can easily solve the points 1 and 2 as [Spine][spine-web-site] provides 
+options to mark the fields as `required` and validate values of the numeric 
+fields.
 
 Let's add these elements to the `Board` definition:
 
 ```protobuf
-// A board for TicTacToe game.
+// A board for Tic-tac-toe game.
 message Board {
   // The name of the board.
   BoardName name = 1 [(required) = true];
@@ -87,14 +86,16 @@ message Board {
   // The size of the board.
   int32 side_size = 2 [(required) = true, (min).value = "3"];
 
-  // Board cells. It is expected to have "side_size * side_size" cells.
+  // Board cells. The collection must not be empty.
   repeated Cell cell = 3 [(required) = true];
 }
 ...
 ```
 
-Also, we can define a custom option to check the size of the `cell` field
-and use ProtoData API to generate the required validation code.
+To solve the point 3, we can define a custom option so we could set the 
+required size for a repeated field and use ProtoData API to extend the generated 
+by Protobuf code with the additional logic that checks the instances of Proto 
+messages for validness at runtime. So let's do it.
 
 Below is definition of the `size` custom option:
 ```protobuf
@@ -125,7 +126,7 @@ message ArrayOfSizeOption {
 Now let's use this option in the `Board` definition:
 
 ```protobuf
-// A board for TicTacToe game.
+// A board for Tic-tac-toe game.
 message Board {
   // The name of the board.
   BoardName name = 1 [(required) = true];
@@ -138,19 +139,19 @@ message Board {
   //
   int32 side_size = 2 [(required) = true, (min).value = "3"];
 
-  // Board cells. It is expected to have "side_size * side_size" cells.
+  // Board cells. It is required to have "side_size * side_size" cells.
   repeated Cell cell = 3 [(required) = true, (size).value = "side_size * side_size"];
 }
 ...
 ```
 
-The [ApplySizeOptionPlugin](codegen-plugin/src/main/kotlin/io/spine/examples/protodata/hello/plugin/ApplySizeOptionPlugin.kt) 
-is implemented to generate the validation code for the `size` option. 
-It uses ProtoData API to customize the code generation for Protobuf messages.
+The [ApplySizeOptionPlugin][plugin-source] is implemented to generate 
+the validation code for the `size` option. This plugin uses ProtoData API
+to collect the `size` option metadata and to generate extensions 
+for the message builder classes with validation methods for every field 
+with `size` option applied.
 
-The plugin generates extensions for the message builder classes
-with validation methods for every field with `size` option applied.
-Below is the generated validation method for the `cell` field.
+Below is generated validation method for the `Board.cell` field.
 
 ```kotlin
 internal fun Board.Builder.validateCellCount(): Board.Builder {
@@ -164,9 +165,9 @@ internal fun Board.Builder.validateCellCount(): Board.Builder {
 ```
 
 Also, the `build()` method of a message builder class is updated
-to call these methods.
+to call such methods.
 
-See the [codegen-plugin](codegen-plugin) subproject for details.
+See the [codegen-plugin][plugin-module] subproject for details.
 
 The following configuration should be applied in the Gradle configuration 
 of a module to use the `size` option plugin:
@@ -189,7 +190,7 @@ This example is implemented using the following technologies and tools:
 2. Kotlin 1.9.23
 3. Gradle 7.6
 
-### Build Instruction
+### Building locally
 
 1. Clone the repository:
 ```bash
@@ -199,3 +200,16 @@ git clone git@github.com:spine-examples/Hello-ProtoData.git
 ```bash
 ./gradlew build
 ```
+
+[gh-actions]: https://github.com/spine-examples/Hello-ProtoData/actions
+[ubuntu-build-badge]: https://github.com/spine-examples/Hello-ProtoData/actions/workflows/build-on-ubuntu.yml/badge.svg
+[windows-build-badge]: https://github.com/spine-examples/Hello-ProtoData/actions/workflows/build-on-windows.yml/badge.svg
+[license-badge]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat
+[apache-license]: http://www.apache.org/licenses/LICENSE-2.0
+
+[proto3-options]: https://protobuf.dev/programming-guides/proto3/#options
+[descriptor-proto]: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto
+[proto3-custom-options]: https://protobuf.dev/programming-guides/proto3/#customoptions
+[plugin-source]: codegen-plugin/src/main/kotlin/io/spine/examples/protodata/hello/plugin/ApplySizeOptionPlugin.kt
+[plugin-module]: codegen-plugin
+[spine-web-site]: https://spine.io/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
+# Introduction
+
+### How Proto messages are semantically enriched with options.
+
+### How we want to reflect this semantic meaning in our code.
+
+
+### ProtoData to rescue.
+
+# Domain
+
+### Naked Board code (no options).
+
+### Rules we want to enforce to this domain (restrictions on the size, etc).
+
+### Declaring a Proto option to bring the required semantic rules.
+
+### Using it in Proto code (Board with the options used).
+
+### References to ProtoData plugin codebase which does the trick.
+
+### Summary: usage examples of Board, pointing out the validation rules added upon build-ing the Proto messages.
+
+# Development
+
+### Pre-requisites (JDK, Gradle, etc.).
+
+### Build instructions.
+
+
+
+
+
+
+# The old version below
 # Hello-ProtoData
 An example on code generation with ProtoData.
 


### PR DESCRIPTION
This PR includes updates to README.md made according to the following plan:

**Introduction**

- How Proto messages are semantically enriched with options.
- How we want to reflect this semantic meaning in our code.
- ProtoData to rescue.

**Domain**

- Naked Board code (no options).
- Rules we want to enforce to this domain (restrictions on the size, etc).
- Declaring a Proto option to bring the required semantic rules.
- Using it in Proto code (Board with the options used).
- References to ProtoData plugin codebase which does the trick.
- Summary: usage examples of Board, pointing out the validation rules added upon build-ing the Proto messages.

**Development**

- Pre-requisites (JDK, Gradle, etc.).
- Build instructions.
