### PR TITLE
Migrate to the latest version of `ProtoData`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ plugins {
     id("net.ltgt.errorprone")
     id("detekt-code-analysis")
     id("com.google.protobuf")
-    id("io.spine.protodata") version "0.50.0"
+    id("io.spine.protodata") version "0.60.3"
     idea
 }
 

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -122,6 +122,10 @@ private fun ResolutionStrategy.forceProductionDependencies() {
         KotlinX.Coroutines.core,
         KotlinX.Coroutines.jvm,
         KotlinX.Coroutines.jdk8,
+        KotlinX.Coroutines.bom,
+        KotlinX.Coroutines.debug,
+        KotlinX.Coroutines.test,
+        KotlinX.Coroutines.testJvm,
         Protobuf.GradlePlugin.lib,
         Protobuf.libs,
         Slf4J.lib

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HelloProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HelloProtoData.kt
@@ -39,7 +39,7 @@ object HelloProtoData {
 
     const val group = "io.spine.examples"
 
-    private const val version = "0.50.0"
+    private const val version = "0.60.3"
     private const val prefix = "hello-protodata-"
 
     object ProtoExtension {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinX.kt
@@ -38,5 +38,9 @@ object KotlinX {
         const val core = "$group:kotlinx-coroutines-core:$version"
         const val jvm = "$group:kotlinx-coroutines-core-jvm:$version"
         const val jdk8 = "$group:kotlinx-coroutines-jdk8:$version"
+        const val bom = "$group:kotlinx-coroutines-bom:$version"
+        const val debug = "$group:kotlinx-coroutines-debug:$version"
+        const val test = "$group:kotlinx-coroutines-test:$version"
+        const val testJvm = "$group:kotlinx-coroutines-test-jvm:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -53,7 +53,8 @@ package io.spine.internal.dependency
  */
 @Suppress(
     "unused" /* Some subprojects do not use ProtoData directly. */,
-    "MemberVisibilityCanBePrivate" /* The properties are used directly by other subprojects. */
+    "MemberVisibilityCanBePrivate" /* The properties are used directly by other subprojects. */,
+    "ConstPropertyName" /* Suppress warnings on lover-case property names. */
 )
 object ProtoData {
     const val group = "io.spine.protodata"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -62,7 +62,7 @@ object ProtoData {
     /**
      * The version of ProtoData dependencies.
      */
-    const val version: String = "0.50.0"
+    const val version: String = "0.60.3"
 
     const val lib: String =
         "io.spine:protodata:$version"

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     protoData(project(":codegen-plugin"))
 
     testImplementation(JUnit.runner)
-
     testImplementation(Spine.pluginTestlib)
     testImplementation(Spine.McJava.pluginLib)
     testImplementation(gradleTestKit())

--- a/integration-tests/src/test/kotlin/io/spine/examples/protodata/hello/test/ApplySizeOptionPluginTest.kt
+++ b/integration-tests/src/test/kotlin/io/spine/examples/protodata/hello/test/ApplySizeOptionPluginTest.kt
@@ -25,16 +25,17 @@
  */
 package io.spine.examples.protodata.hello.test
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
 import io.spine.examples.protodata.hello.ArrayOfSizeOption
 import io.spine.tools.gradle.testing.GradleProject
 import io.spine.tools.mc.java.gradle.McJavaTaskName
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.gradle.testkit.runner.internal.DefaultGradleRunner
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.io.StringWriter
@@ -77,28 +78,23 @@ class `ApplySizeOptionPlugin should` {
                 .validatePhoneCount()
 
             val invalidContactBuilder = createInvalidContactBuilder()
-            assertThrows<IllegalStateException> {
-                invalidContactBuilder
-                    .validatePhoneCount()
+            shouldThrow<IllegalStateException> {
+                invalidContactBuilder.validatePhoneCount()
             }
-            assertThrows<IllegalStateException> {
-                invalidContactBuilder
-                    .validateAddressCount()
+            shouldThrow<IllegalStateException> {
+                invalidContactBuilder.validateAddressCount()
             }
-            assertThrows<IllegalStateException> {
-                invalidContactBuilder
-                    .validateEmailCount()
+            shouldThrow<IllegalStateException> {
+                invalidContactBuilder.validateEmailCount()
             }
         }
 
         @Test
         fun `by calling field validation methods inside 'build()' method`() {
-            createValidContactBuilder()
-                .build()
+            createValidContactBuilder().build()
 
-            assertThrows<IllegalStateException> {
-                createInvalidContactBuilder()
-                    .build()
+            shouldThrow<IllegalStateException> {
+                createInvalidContactBuilder().build()
             }
         }
     }
@@ -107,7 +103,6 @@ class `ApplySizeOptionPlugin should` {
     fun `fail the build if 'size' option value is not set`(
         @TempDir projectDir: File
     ) {
-
         val expectedExceptionMessage = "Value of `size` option for " +
                 "field `SizeOptionTestMsg.empty_expression_field` is not set."
 
@@ -122,7 +117,6 @@ class `ApplySizeOptionPlugin should` {
     fun `fail the build if 'size' option is applied to non-repeated field`(
         @TempDir projectDir: File
     ) {
-
         val expectedExceptionMessage = "Field " +
                 "`SizeOptionTestMsg.non_repeated_field` is non-repeated " +
                 "and therefore cannot be validated with `size` option."
@@ -139,7 +133,6 @@ class `ApplySizeOptionPlugin should` {
         protoSourceFile: File,
         expectedExceptionMessage: String
     ) {
-
         val project = GradleProject.setupAt(projectDir)
             .fromResources(TEST_PROJECT_DIR)
             .copyBuildSrc()
@@ -157,9 +150,9 @@ class `ApplySizeOptionPlugin should` {
         } catch (_: UnexpectedBuildFailure) {
         }
 
-        assertTrue(
-            stderr.toString().contains(expectedExceptionMessage),
-            "The expected exception was not thrown."
-        )
+        withClue("The expected exception was not thrown.") {
+            stderr.toString()
+                .contains(expectedExceptionMessage) shouldBe true
+        }
     }
 }

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -24,6 +24,7 @@
  */
 
 import io.spine.internal.dependency.JUnit
+import io.spine.internal.dependency.Kotest
 import io.spine.internal.dependency.Validation
 
 dependencies {
@@ -37,6 +38,7 @@ dependencies {
     implementation(Validation.runtime)
 
     testImplementation(JUnit.runner)
+    testImplementation(Kotest.assertions)
 }
 
 apply {

--- a/model/src/test/kotlin/io/spine/examples/protodata/hello/model/test/SizeOptionPluginTest.kt
+++ b/model/src/test/kotlin/io/spine/examples/protodata/hello/model/test/SizeOptionPluginTest.kt
@@ -26,12 +26,12 @@
 
 package io.spine.examples.protodata.hello.model.test
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.spine.examples.protodata.hello.ArrayOfSizeOption
 import io.spine.examples.protodata.hello.model.Board
 import io.spine.examples.protodata.hello.model.Cell
 import io.spine.examples.protodata.hello.model.validateCellCount
-import io.spine.examples.protodata.hello.ArrayOfSizeOption
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 /**
  * Checks the generated validation code for the [ArrayOfSizeOption]
@@ -41,23 +41,19 @@ class `SizeOptionPlugin should` {
 
     @Test
     fun `generate custom validation method for the field`() {
-        createBoardBuilder(true)
-            .validateCellCount()
+        createBoardBuilder(true).validateCellCount()
 
-        assertThrows<IllegalStateException> {
-            createBoardBuilder(false)
-                .validateCellCount()
+        shouldThrow<IllegalStateException> {
+            createBoardBuilder(false).validateCellCount()
         }
     }
 
     @Test
     fun `integrate validation code into 'build()' method`() {
-        createBoardBuilder(true)
-            .build()
+        createBoardBuilder(true).build()
 
-        assertThrows<IllegalStateException> {
-            createBoardBuilder(false)
-                .build()
+        shouldThrow<IllegalStateException> {
+            createBoardBuilder(false).build()
         }
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,4 +30,4 @@
  * This version also used by integration tests, so if you chage the version,
  * please also update it in the [io.spine.internal.dependency.HelloProtoData].
  */
-val helloProtoDataVersion: String by extra("0.50.0")
+val helloProtoDataVersion: String by extra("0.60.3")


### PR DESCRIPTION
This PR updates the version of ProtoData to `0.60.3`.

Also, the `Kotest` assertions are used in tests.
